### PR TITLE
fix: option parsing in bwa aln

### DIFF
--- a/pybwa/libbwaaln.pyi
+++ b/pybwa/libbwaaln.pyi
@@ -23,6 +23,7 @@ class BwaAlnOptions:
         max_hits: int | None = 3,
         log_scaled_gap_penalty: bool | None = None,
         find_all_hits: bool | None = None,
+        with_md: bool | None = None,
         threads: int | None = None,
     ) -> None: ...
     max_mismatches: int  # -n <int>

--- a/pybwa/libbwaaln.pyx
+++ b/pybwa/libbwaaln.pyx
@@ -63,6 +63,8 @@ cdef class BwaAlnOptions:
                  ):
         if max_mismatches is not None:
             self.max_mismatches = max_mismatches
+        if max_gap_opens is not None:
+            self.max_gap_opens = max_gap_opens
         if max_gap_extensions is not None:
             self.max_gap_extensions = max_gap_extensions
         if min_indel_to_end_distance is not None:
@@ -84,7 +86,7 @@ cdef class BwaAlnOptions:
         if max_hits is not None:
             self.max_hits = max_hits
         if log_scaled_gap_penalty is not None:
-            self.log_scaled_gap_penalty = 1 if log_scaled_gap_penalty else 0
+            self.log_scaled_gap_penalty = log_scaled_gap_penalty
         if find_all_hits is not None:
             self.find_all_hits = find_all_hits
         if with_md is not None:
@@ -105,9 +107,10 @@ cdef class BwaAlnOptions:
     property max_mismatches:
         """:code:`bwa aln -n <int>`"""
         def __get__(self) -> int:
-            return self._delegate.s_mm
+            return self._delegate.max_diff
         def __set__(self, value: int):
-            self._delegate.s_mm = value
+            self._delegate.fnr = -1.0
+            self._delegate.max_diff = value
 
     property max_gap_opens:
         """:code:`bwa aln -o <int>`"""
@@ -119,7 +122,7 @@ cdef class BwaAlnOptions:
     property max_gap_extensions:
         """:code:`bwa aln -e <int>`"""
         def __get__(self) -> int:
-            return self._delegate.max_gapo
+            return self._delegate.max_gape
         def __set__(self, value: int):
             self._delegate.max_gape = value
             if self._delegate.max_gape > 0:
@@ -270,7 +273,6 @@ cdef class BwaAln:
                 for i, sequence in enumerate(queries)
             ]
         opt = BwaAlnOptions() if opt is None else opt
-
 
         return self._calign(opt,  queries)
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybwa"
-version = "1.3.0"
+version = "1.3.1"
 description = "Python bindings for BWA"
 authors = ["Nils Homer"]
 license = "MIT"

--- a/tests/test_bwapy.py
+++ b/tests/test_bwapy.py
@@ -105,6 +105,30 @@ def test_bwaaln_threading(ref_fasta: Path, fastx_record: FastxRecord) -> None:
         assert rec.cigarstring == "80M"
 
 
+def test_bwa_aln_map_one_multi_mapped_max_hits_one(ref_fasta: Path) -> None:
+    """Tests that a query that returns too many hits (>max_hits) returns the number of hits but
+    not the list of hits themselves."""
+    opt = BwaAlnOptions(
+        threads=2,
+        max_hits=1,
+        max_mismatches=3,
+        max_mismatches_in_seed=3,
+        max_gap_opens=0,
+        max_gap_extensions=-1,
+        min_indel_to_end_distance=3,
+        seed_length=20,
+        find_all_hits=True,
+        with_md=True,
+    )
+    bwa = BwaAln(prefix=ref_fasta)
+    queries = [FastxRecord(name="NA", sequence="TTTTT")]
+    recs = bwa.align(opt=opt, queries=queries)
+    assert len(recs) == 1
+    rec = recs[0]
+    assert rec.has_tag("HN"), str(rec)
+    assert rec.get_tag("HN") == 3269888
+
+
 def test_bwamem_options() -> None:
     # default options
     options = BwaMemOptions()


### PR DESCRIPTION
1. the with_md constructor argument was missing
2. the max_gap_opens constructor argument is now used (was ignored)
3. the log_scaled_gap_penalty constructor argument was improperly used
4. the max_mismatches property set and returned the wrong value (mismatch penalty), and did not set the FNR to -1 so that max mismatches would be used.
5. the max gap extensions property returned the wrong value (max gap opens).

<!-- readthedocs-preview pybwa start -->
----
📚 Documentation preview 📚: https://pybwa--38.org.readthedocs.build/en/38/

<!-- readthedocs-preview pybwa end -->