### PR TITLE
fix: properly defect the Linux platform during build

### DIFF
--- a/build.py
+++ b/build.py
@@ -55,7 +55,7 @@ compile_args = []
 link_args = []
 include_dirs = ["bwa", "pybwa"]
 libraries = ['m', 'z', 'pthread']
-if platform == 'Linux':
+if platform.system() == 'Linux':
     libraries.append("rt")
 library_dirs=['pybwa', 'bwa']
 extra_objects = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybwa"
-version = "1.3.3"
+version = "1.3.4"
 description = "Python bindings for BWA"
 authors = ["Nils Homer"]
 license = "MIT"


### PR DESCRIPTION


<!-- readthedocs-preview pybwa start -->
----
📚 Documentation preview 📚: https://pybwa--41.org.readthedocs.build/en/41/

<!-- readthedocs-preview pybwa end -->