### PR TITLE
Fix bwa mem reproducibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybwa"
-version = "1.4.0"
+version = "1.4.1"
 description = "Python bindings for BWA"
 authors = ["Nils Homer"]
 license = "MIT"


### PR DESCRIPTION
Pybwa was not enforcing the _even_ number of reads.
    
Also, a bug was fixed passing the number of already processed reads when
multiple chunks are aligned with bwa mem.  This is important as the #
are hashed when choosing a primary versus secondary alignment.

<!-- readthedocs-preview pybwa start -->
----
📚 Documentation preview 📚: https://pybwa--44.org.readthedocs.build/en/44/

<!-- readthedocs-preview pybwa end -->