### PR TITLE
Fix issue with `str` paths in `BwaIndex.index`

### DIFF
--- a/pybwa/libbwaindex.pyx
+++ b/pybwa/libbwaindex.pyx
@@ -93,7 +93,7 @@ cdef class BwaIndex:
         bwa_idx_build(force_bytes(f"{fasta}"), force_bytes(f"{prefix}"), method.value, block_size)
 
         # Build the sequence dictionary
-        dict_fn = Path(prefix.with_suffix(".dict"))
+        dict_fn = Path(prefix).with_suffix(".dict")
         samtools.dict("-o", f"{dict_fn}", f"{fasta}")
 
 


### PR DESCRIPTION
This PR fixes a small bracket typo in `BwaIndex.index`. 

Currently, calling it with a `str` path causes the following error:
```python
Traceback (most recent call last):
  File "/home/althonos/Code/pybwa/bug.py", line 5, in <module>
    index = pybwa.BwaIndex.index("test.fasta")
  File "pybwa/libbwaindex.pyx", line 96, in pybwa.libbwaindex.BwaIndex.index
AttributeError: 'str' object has no attribute 'with_suffix'
```

<!-- readthedocs-preview pybwa start -->
----
📚 Documentation preview 📚: https://pybwa--56.org.readthedocs.build/en/56/

<!-- readthedocs-preview pybwa end -->