### PR TITLE
Use `cigartuples` instead of `cigarstring` to update `AlignedSegment` CIGARs

### DIFF
--- a/pybwa/libbwaaln.pxd
+++ b/pybwa/libbwaaln.pxd
@@ -27,6 +27,11 @@ cdef extern from "bwtaln.h":
     int BWA_MODE_LOGGAP
     int BWA_MODE_NONSTOP
 
+    const int FROM_M
+    const int FROM_I
+    const int FROM_D
+    const int FROM_S
+
     int __cigar_op(uint16_t __cigar)
     int __cigar_len(uint16_t __cigar)
 

--- a/pybwa/libbwaaln.pyx
+++ b/pybwa/libbwaaln.pyx
@@ -356,15 +356,15 @@ cdef class BwaAln:
         rec.mapping_quality = seq.mapQ
 
         # cigar
-        cigar = ""
+        cigartuples = []
         if seq.cigar:
             for j in range(seq.n_cigar):
                 cigar_len = __cigar_len(seq.cigar[j])
-                cigar_op = "MIDS"[__cigar_op(seq.cigar[j])]
-                cigar = f"{cigar}{cigar_len}{cigar_op}"
+                cigar_op = __cigar_op(seq.cigar[j])
+                cigartuples.append((cigar_op, cigar_len))
         elif seq.type != BWA_TYPE_NO_MATCH:
             cigar = f"{seq.len}M"
-        rec.cigarstring = cigar
+        rec.cigartuples = cigartuples
 
         # # tags
         if seq.type != BWA_TYPE_NO_MATCH:

--- a/pybwa/libbwaaln.pyx
+++ b/pybwa/libbwaaln.pyx
@@ -372,7 +372,7 @@ cdef class BwaAln:
                 cigar_op = __cigar_op(seq.cigar[j])
                 cigartuples.append((_to_pysam_cigar_op(cigar_op), cigar_len))
         elif seq.type != BWA_TYPE_NO_MATCH:
-            cigartuples.append((pysam.CMATCH, seq.len))
+            cigartuples.append((CMATCH, seq.len))
         rec.cigartuples = cigartuples
 
         # # tags

--- a/pybwa/libbwaaln.pyx
+++ b/pybwa/libbwaaln.pyx
@@ -8,7 +8,7 @@ import pysam
 from libc.stdint cimport uint8_t
 from libc.stdlib cimport calloc, free
 from libc.string cimport strncpy
-from pysam import FastxRecord, AlignedSegment, qualitystring_to_array
+from pysam import FastxRecord, AlignedSegment, qualitystring_to_array, CMATCH, CINS, CDEL, CSOFT_CLIP
 from pybwa.libbwaindex cimport force_bytes
 from pybwa.libbwaindex cimport BwaIndex
 
@@ -19,10 +19,10 @@ __all__ = [
 ]
 
 cdef int _BWA_ALN_TO_PYSAM_CIGAR_OPERATOR[4]
-_BWA_ALN_TO_PYSAM_CIGAR_OPERATOR[FROM_M] = pysam.CMATCH
-_BWA_ALN_TO_PYSAM_CIGAR_OPERATOR[FROM_I] = pysam.CINS
-_BWA_ALN_TO_PYSAM_CIGAR_OPERATOR[FROM_D] = pysam.CDEL
-_BWA_ALN_TO_PYSAM_CIGAR_OPERATOR[FROM_S] = pysam.CSOFT_CLIP
+_BWA_ALN_TO_PYSAM_CIGAR_OPERATOR[FROM_M] = CMATCH
+_BWA_ALN_TO_PYSAM_CIGAR_OPERATOR[FROM_I] = CINS
+_BWA_ALN_TO_PYSAM_CIGAR_OPERATOR[FROM_D] = CDEL
+_BWA_ALN_TO_PYSAM_CIGAR_OPERATOR[FROM_S] = CSOFT_CLIP
 
 cdef inline int _to_pysam_cigar_op(int x):
     return _BWA_ALN_TO_PYSAM_CIGAR_OPERATOR[x]

--- a/pybwa/libbwaaln.pyx
+++ b/pybwa/libbwaaln.pyx
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import List
 from fgpyo.sequence import reverse_complement
 
-import pysam
 from libc.stdint cimport uint8_t
 from libc.stdlib cimport calloc, free
 from libc.string cimport strncpy

--- a/pybwa/libbwamem.pyx
+++ b/pybwa/libbwamem.pyx
@@ -2,13 +2,12 @@
 from pathlib import Path
 from typing import List
 
-import pysam
 from fgpyo.sequence import reverse_complement
 from libc.string cimport memcpy
 from libc.stdlib cimport calloc, free
 import enum
 from pybwa.libbwaindex cimport BwaIndex
-from pysam import FastxRecord, AlignedSegment, qualitystring_to_array
+from pysam import FastxRecord, AlignedSegment, qualitystring_to_array, CMATCH, CINS, CDEL, CSOFT_CLIP, CHARD_CLIP
 from libc.string cimport strncpy
 from pybwa.libbwaindex cimport force_bytes
 
@@ -20,11 +19,11 @@ __all__ = [
 ]
 
 cdef int _BWA_MEM_TO_PYSAM_CIGAR_OPERATOR[5]
-_BWA_MEM_TO_PYSAM_CIGAR_OPERATOR[0] = pysam.CMATCH
-_BWA_MEM_TO_PYSAM_CIGAR_OPERATOR[1] = pysam.CINS
-_BWA_MEM_TO_PYSAM_CIGAR_OPERATOR[2] = pysam.CDEL
-_BWA_MEM_TO_PYSAM_CIGAR_OPERATOR[3] = pysam.CSOFT_CLIP
-_BWA_MEM_TO_PYSAM_CIGAR_OPERATOR[4] = pysam.CHARD_CLIP
+_BWA_MEM_TO_PYSAM_CIGAR_OPERATOR[0] = CMATCH
+_BWA_MEM_TO_PYSAM_CIGAR_OPERATOR[1] = CINS
+_BWA_MEM_TO_PYSAM_CIGAR_OPERATOR[2] = CDEL
+_BWA_MEM_TO_PYSAM_CIGAR_OPERATOR[3] = CSOFT_CLIP
+_BWA_MEM_TO_PYSAM_CIGAR_OPERATOR[4] = CHARD_CLIP
 
 cdef inline int _to_pysam_cigar_op(int x):
     return _BWA_MEM_TO_PYSAM_CIGAR_OPERATOR[x]

--- a/pybwa/libbwamem.pyx
+++ b/pybwa/libbwamem.pyx
@@ -898,7 +898,7 @@ cdef class BwaMem:
                 rec.reference_id = mem_aln.rid
                 rec.reference_start = mem_aln.pos
                 rec.mapping_quality = mem_aln.mapq
-                cigar = ""
+                cigartuples = []
                 cigar_len_sum = 0
                 for k in range(mem_aln.n_cigar):
                     cigar_op = mem_aln.cigar[k] & 0xf
@@ -906,10 +906,10 @@ cdef class BwaMem:
                             cigar_op == 3 or cigar_op == 4):
                         cigar_op = 4 if j > 0 else 3  # // use hard clipping for supplementary alignments
                     cigar_len = mem_aln.cigar[k] >> 4
-                    cigar += f"{cigar_len}" + "MIDSH"[cigar_op]
+                    cigartuples.append((cigar_op, cigar_len))
                     if cigar_op < 4:
                         cigar_len_sum += cigar_len
-                rec.cigarstring = cigar
+                rec.cigartuples = cigartuples
 
                 # remove leading and trailing soft-clipped bases for non-primary etc.
                 if mem_aln.n_cigar > 0 and j > 0 and not opt.soft_clip_supplementary and mem_aln.is_alt == 0:


### PR DESCRIPTION
Hi again!

This PR proposes to use the `cigartuples` property of `AlignedSegment` to update the CIGAR in `BwaMem._calign` and `BwaAln._build_alignment`. 

In `pysam`, the `cigarstring` is only exposed for convenience while the actual CIGAR operations are stored in an array. This means that setting the `cigarstring` attribute on an `AlignedSegment` actual requires parsing the cigar string back into an array:

https://github.com/pysam-developers/pysam/blob/3e3c8b0b5ac066d692e5c720a85d293efc825200/pysam/libcalignedsegment.pyx#L1323-L1329

Using `cigartuples` avoids creating a string that is immediately parsed back.

<!-- readthedocs-preview pybwa start -->
----
📚 Documentation preview 📚: https://pybwa--58.org.readthedocs.build/en/58/

<!-- readthedocs-preview pybwa end -->