### PR TITLE
chore: update CIBW_MANYLINUX_X86_64_IMAGE in wheels build to manylinu…

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -63,8 +63,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
 
           # linux
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          # manylinux2014 can't build on aarch64
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
           CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_2
           CIBW_MUSLLINUX_AARCH64_IMAGE: musllinux_1_2


### PR DESCRIPTION
…x_2_28

This should speed up wheel builds for a few builds.

See: https://github.com/fulcrumgenomics/pybwa/issues/62

<!-- readthedocs-preview pybwa start -->
----
📚 Documentation preview 📚: https://pybwa--63.org.readthedocs.build/en/63/

<!-- readthedocs-preview pybwa end -->