### PR TITLE
ci: use ubuntu-22.04-arm for manylinux_aarch64 and musllinux_aarch64

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,7 +30,7 @@ jobs:
           if [[ "${{ github.event_name == 'pull_request' || inputs.skip }}" == "true" ]]; then
             echo 'buildplat=[["ubuntu-22.04", "manylinux_x86_64"], ["ubuntu-22.04", "musllinux_x86_64"], ["macos-13", "macosx_x86_64"], ["macos-15", "macosx_arm64"]]' >> "$GITHUB_OUTPUT"
           else
-            echo 'buildplat=[["ubuntu-22.04", "manylinux_x86_64"], ["ubuntu-22.04", "musllinux_x86_64"], ["ubuntu-22.04", "manylinux_aarch64"], ["ubuntu-22.04", "musllinux_aarch64"], ["macos-13", "macosx_x86_64"], ["macos-15", "macosx_arm64"]]' >> "$GITHUB_OUTPUT"
+            echo 'buildplat=[["ubuntu-22.04", "manylinux_x86_64"], ["ubuntu-22.04", "musllinux_x86_64"], ["ubuntu-22.04-arm", "manylinux_aarch64"], ["ubuntu-22.04-arm", "musllinux_aarch64"], ["macos-13", "macosx_x86_64"], ["macos-15", "macosx_arm64"]]' >> "$GITHUB_OUTPUT"
           fi
               
   build-wheels:


### PR DESCRIPTION
As suggested here: https://github.com/fulcrumgenomics/pybwa/issues/62#issuecomment-2727150074

See: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

