### PR TITLE
chore: add test coverage for bwa aln returning XN

### DIFF
--- a/pybwa/__init__.py
+++ b/pybwa/__init__.py
@@ -6,7 +6,7 @@ from pybwa.libbwaindex import *  # noqa: F403
 from pybwa.libbwamem import *  # noqa: F403
 
 
-def _get_include() -> list[str]:
+def _get_include() -> list[str]:  # pragma: no cover
     """return a list of include directories."""
     dirname = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 

--- a/pybwa/libbwaindex.pyx
+++ b/pybwa/libbwaindex.pyx
@@ -30,7 +30,9 @@ cdef bytes force_bytes(object s):
     return force_bytes_with(s, None, None)
 
 
-cdef bytes force_bytes_with(object s, encoding: str | None = None, errors: str | None = None):
+cdef bytes force_bytes_with(
+    object s, encoding: str | None = None, errors: str | None = None
+): # pragma: no cover
     """convert string or unicode object to bytes, assuming utf8 encoding."""
     if s is None:
         return None

--- a/pybwa/libbwamem.pyx
+++ b/pybwa/libbwamem.pyx
@@ -223,7 +223,7 @@ cdef class BwaMemOptions:
         free(self._options0)
         self._options0 = NULL
 
-    cdef mem_opt_t* mem_opt(self):
+    cdef mem_opt_t* mem_opt(self):  # pragma: no cover
         """Returns the options struct to use with the bwa C library methods"""
         if not self._finalized:
             raise Exception("Cannot call `mem_opt` until `finalize()` is called")

--- a/pybwa/libbwamem.pyx
+++ b/pybwa/libbwamem.pyx
@@ -223,7 +223,7 @@ cdef class BwaMemOptions:
         free(self._options0)
         self._options0 = NULL
 
-    cdef mem_opt_t* mem_opt(self)
+    cdef mem_opt_t* mem_opt(self):
         """Returns the options struct to use with the bwa C library methods"""
         if not self._finalized:  # pragma: no cover
             raise Exception("Cannot call `mem_opt` until `finalize()` is called")

--- a/pybwa/libbwamem.pyx
+++ b/pybwa/libbwamem.pyx
@@ -223,9 +223,9 @@ cdef class BwaMemOptions:
         free(self._options0)
         self._options0 = NULL
 
-    cdef mem_opt_t* mem_opt(self):  # pragma: no cover
+    cdef mem_opt_t* mem_opt(self)
         """Returns the options struct to use with the bwa C library methods"""
-        if not self._finalized:
+        if not self._finalized:  # pragma: no cover
             raise Exception("Cannot call `mem_opt` until `finalize()` is called")
         return self._options
 


### PR DESCRIPTION
This occurs when there are ambiguous bases in the reference.

Also, add pragmas to functions/code that will not have planned test coverage.

<!-- readthedocs-preview pybwa start -->
----
📚 Documentation preview 📚: https://pybwa--71.org.readthedocs.build/en/71/

<!-- readthedocs-preview pybwa end -->