### PR TITLE
ci: add retry to building extensions and building wheels.

### DIFF
--- a/.github/actions/cibuildwheel/action.yaml
+++ b/.github/actions/cibuildwheel/action.yaml
@@ -1,0 +1,34 @@
+name: Build wheels
+author: Nils Homer (@nh13)
+description: 'Builds wheels, falling back to no parellism if the first attempt fails'
+
+branding:
+  icon: "code"
+  color: "green"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build wheels
+      id: build-wheels
+      uses: pypa/cibuildwheel@v2.22.0
+      continue-on-error: true
+      with:
+        package-dir: .
+        output-dir: wheelhouse
+        config-file: "{package}/pyproject.toml"
+
+    - name: Set no parallism
+      shell: bash
+      if: ${{ steps.build-wheels.conclusion == 'failure' }}
+      run: |
+        echo "BUILD_EXTENSIONS_PARALLEL=false" >> $GITHUB_ENV
+        export "BUILD_EXTENSIONS_PARALLEL=false"
+
+    - name: Build wheels (retry without parallelism)
+      uses: pypa/cibuildwheel@v2.22.0
+      if: ${{ steps.build-wheels.conclusion == 'failure' }}
+      with:
+        package-dir: .
+        output-dir: wheelhouse
+        config-file: "{package}/pyproject.toml"

--- a/.github/workflows/publish_pybwa.yml
+++ b/.github/workflows/publish_pybwa.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'true'
-      
+
       - name: debug git branch -a
         shell: bash
         run: git branch -a
@@ -72,10 +72,23 @@ jobs:
         run: poetry config virtualenvs.in-project true
 
       - name: Install dependencies
+        shell: bash
         run: poetry install --no-interaction --no-root --without=dev
 
-      - name: Install project
-        run: poetry install --no-interaction --without=dev
+      - name: Install pybwa
+        uses: nick-fields/retry@v3
+        with:
+          shell: bash
+          max_attempts: 2
+          retry_on: error
+          polling_interval_seconds: 5
+          timeout_minutes: 90
+          command: |
+            poetry install --no-interaction --without=dev
+            poetry run python -c "import pybwa"
+          on_retry_command: |
+            echo "BUILD_EXTENSIONS_PARALLEL=false" >> $GITHUB_ENV
+            export "BUILD_EXTENSIONS_PARALLEL=false"
 
       - name: Build package
         run: poetry build --format=sdist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,15 +60,24 @@ jobs:
       run: |
         poetry check
 
-    - name: Install deps
+    - name: Install dependencies
       shell: bash
-      run: |
-        poetry install
+      run: poetry install --no-interaction --no-root
 
-    - name: Check import pybwa
-      shell: bash
-      run: |
-        poetry run python -c "import pybwa"
+    - name: Install pybwa
+      uses: nick-fields/retry@v3
+      with:
+        shell: bash
+        max_attempts: 2
+        retry_on: error
+        polling_interval_seconds: 5
+        timeout_minutes: 90
+        command: |
+          poetry install --no-interaction
+          poetry run python -c "import pybwa"
+        on_retry_command: |
+          echo "BUILD_EXTENSIONS_PARALLEL=false" >> $GITHUB_ENV
+          export "BUILD_EXTENSIONS_PARALLEL=false"
 
     - name: Style checking
       shell: bash

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,7 +19,7 @@ on:
         required: false
         type: boolean
         default: true
-        
+
 jobs:
   define-pybwa-version:
     name: Get the pybwa version
@@ -30,6 +30,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: 'true'
+
     - name: Set up Python 3.12
       uses: actions/setup-python@v1
       with:
@@ -40,6 +41,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry==${{env.POETRY_VERSION}}
+
+    - name: Configure poetry
+      shell: bash
+      run: poetry config virtualenvs.in-project true
 
     - name: Get pybwa version
       id: version
@@ -61,7 +66,7 @@ jobs:
           else
             echo 'buildplat=[["ubuntu-22.04", "manylinux_x86_64"], ["ubuntu-22.04", "musllinux_x86_64"], ["ubuntu-22.04-arm", "manylinux_aarch64"], ["ubuntu-22.04-arm", "musllinux_aarch64"], ["macos-13", "macosx_x86_64"], ["macos-15", "macosx_arm64"]]' >> "$GITHUB_OUTPUT"
           fi
-              
+
   build-wheels:
     name: Build wheels for  ${{ matrix.python-version }}-${{ matrix.buildplat[1] }} input-${{ inputs.skip }}
     runs-on: ${{ matrix.buildplat[0] }}
@@ -81,11 +86,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
-        with:
-          package-dir: .
-          output-dir: wheelhouse
-          config-file: "{package}/pyproject.toml"
+        uses: ./.github/actions/cibuildwheel
         env:
           # select
           CIBW_BUILD: ${{ matrix.python-version }}-${{ matrix.buildplat[1] }}
@@ -104,7 +105,7 @@ jobs:
           CIBW_ARCHS_MACOS: auto64
           CIBW_BEFORE_BUILD_MACOS: "{project}/ci/osx-deps"
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
- 
+
           CIBW_TEST_COMMAND: >
             if (cd ~/ && python -c "import pybwa")
             then

--- a/build.py
+++ b/build.py
@@ -12,6 +12,17 @@ from Cython.Distutils.build_ext import new_build_ext as cython_build_ext
 from setuptools import Extension, Distribution
 
 
+def strtobool(value: str) -> bool:
+    value = value.lower()
+    _TRUE = {'y', 'yes', 't', 'true', 'on', '1'}
+    _FALSE = {'n', 'no', 'f', 'false', 'off', '0'}
+    if value in _TRUE:
+        return True
+    elif value in _FALSE:
+        return False
+    raise ValueError(f'"{value}" is not a valid bool value')
+
+
 @contextmanager
 def changedir(path):
     save_dir = os.getcwd()
@@ -215,7 +226,11 @@ def build():
         # (under the hood, "copy_extensions_to_source" will be called after
         # building the extensions). This is done so Poetry grabs the files
         # during the next step in its build.
-        build_ext_cmd.parallel = True
+        build_ext_cmd.parallel = strtobool(os.environ.get("BUILD_EXTENSIONS_PARALLEL", "True"))
+        if build_ext_cmd.parallel:
+            print("Building cython extensions in parallel")
+        else:
+            print("Building cython extensions serially")
         build_ext_cmd.inplace = 1
         build_ext_cmd.run()
 


### PR DESCRIPTION
Fixes #72.

Update the build.py to look for the `BUILD_EXTENSIONS_PARALLEL`
environment variable.  If set to a truthy value, set parallelism when
building cython extensions in parallel.

Use the nick-fields/retry@v3 action to retry a the `poetry install` step
when it fails turning off building cython extensions in parallel.

Adds a cibuildwheel local action that we can re-use.  If the first
attempt at building a wheel fails, we retry turning off building cython
extensions in parallel.

Separate the installation of dependencies into its own step with
installing the current project.

<!-- readthedocs-preview pybwa start -->
----
📚 Documentation preview 📚: https://pybwa--73.org.readthedocs.build/en/73/

<!-- readthedocs-preview pybwa end -->