### PR TITLE
ci: fix extension building fallback

### DIFF
--- a/.github/actions/cibuildwheel/action.yaml
+++ b/.github/actions/cibuildwheel/action.yaml
@@ -18,13 +18,6 @@ runs:
         output-dir: wheelhouse
         config-file: "{package}/pyproject.toml"
 
-    - name: Set no parallism
-      shell: bash
-      if: ${{ steps.build-wheels.conclusion == 'failure' }}
-      run: |
-        echo "BUILD_EXTENSIONS_PARALLEL=false" >> $GITHUB_ENV
-        export "BUILD_EXTENSIONS_PARALLEL=false"
-
     - name: Build wheels (retry without parallelism)
       uses: pypa/cibuildwheel@v2.22.0
       if: ${{ steps.build-wheels.conclusion == 'failure' }}
@@ -32,3 +25,5 @@ runs:
         package-dir: .
         output-dir: wheelhouse
         config-file: "{package}/pyproject.toml"
+      env:
+        BUILD_EXTENSIONS_PARALLEL: false

--- a/.github/workflows/publish_pybwa.yml
+++ b/.github/workflows/publish_pybwa.yml
@@ -86,9 +86,9 @@ jobs:
           command: |
             poetry install --no-interaction --without=dev
             poetry run python -c "import pybwa"
-          on_retry_command: |
-            echo "BUILD_EXTENSIONS_PARALLEL=false" >> $GITHUB_ENV
-            export "BUILD_EXTENSIONS_PARALLEL=false"
+          new_command_on_retry: |
+            BUILD_EXTENSIONS_PARALLEL=false poetry install --no-interaction --without=dev
+            poetry run python -c "import pybwa"
 
       - name: Build package
         run: poetry build --format=sdist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: 'true'
+
     - name: Set up Python ${{matrix.PYTHON_VERSION}}
       uses: actions/setup-python@v1
       with:
@@ -75,9 +76,9 @@ jobs:
         command: |
           poetry install --no-interaction
           poetry run python -c "import pybwa"
-        on_retry_command: |
-          echo "BUILD_EXTENSIONS_PARALLEL=false" >> $GITHUB_ENV
-          export "BUILD_EXTENSIONS_PARALLEL=false"
+        new_command_on_retry: |
+          BUILD_EXTENSIONS_PARALLEL=false poetry install --no-interaction
+          poetry run python -c "import pybwa"
 
     - name: Style checking
       shell: bash


### PR DESCRIPTION
The nick-fields/retry action does not propagate environment variables using the `on_retry_command` command, so use `new_command_on_retry` instead.

See: https://github.com/nick-fields/retry/issues/153

<!-- readthedocs-preview pybwa start -->
----
📚 Documentation preview 📚: https://pybwa--76.org.readthedocs.build/en/76/

<!-- readthedocs-preview pybwa end -->