### PR TITLE
chore(release): bump to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pybwa"
-version = "1.6.0"
+version = "2.0.0"
 description = "Python bindings for BWA"
 readme = "README.md"
 authors = [{name = "Nils Homer", email = "nils@fulcrumgenomics.com"}]


### PR DESCRIPTION
This is a major version due to breaking API changes.

<!-- readthedocs-preview pybwa start -->
----
📚 Documentation preview 📚: https://pybwa--96.org.readthedocs.build/en/96/

<!-- readthedocs-preview pybwa end -->