### PR TITLE
feat: add the `bwa aln -m` option

### DIFF
--- a/pybwa/libbwaaln.pyi
+++ b/pybwa/libbwaaln.pyi
@@ -24,6 +24,7 @@ class BwaAlnOptions:
         log_scaled_gap_penalty: bool = False,
         find_all_hits: bool = False,
         with_md: bool = False,
+        max_entries: int = 2000000,
         threads: int = 1,
     ) -> None: ...
     max_mismatches: int  # -n <int>
@@ -42,6 +43,7 @@ class BwaAlnOptions:
     log_scaled_gap_penalty: bool = True  # -L
     find_all_hits: bool = False  # -N
     with_md: bool = True  # bwa samse -d
+    max_entries: int = 2000000  # -m <int>
     threads: int  # -t <int>
 
 class BwaAln:

--- a/pybwa/libbwaaln.pyx
+++ b/pybwa/libbwaaln.pyx
@@ -48,6 +48,7 @@ cdef class BwaAlnOptions:
         log_scaled_gap_penalty: :code:`-L`
         find_all_hits: :code:`-N`
         with_md: output the MD to each alignment in the XA tag, otherwise use :code:`"."`
+        max_entries: :code:`-m`
         threads: the number of threads to use
     """
 
@@ -67,6 +68,7 @@ cdef class BwaAlnOptions:
                  log_scaled_gap_penalty: bool = False,
                  find_all_hits: bool = False,
                  with_md: bool = False,
+                 max_entries: int = 2000000,
                  threads: int = 1
                  ):
         if max_mismatches is not None:
@@ -105,6 +107,8 @@ cdef class BwaAlnOptions:
             self.find_all_hits = find_all_hits
         if with_md is not None:
             self.with_md = with_md
+        if max_entries is not None:
+            self.max_entries = max_entries
         if threads is not None:
             self.threads = threads
 
@@ -243,6 +247,13 @@ cdef class BwaAlnOptions:
             return self._with_md
         def __set__(self, value: bool):
            self._with_md = value
+
+    property max_entries:
+        """:code:`bwa aln -m`"""
+        def __get__(self) -> int:
+            return self._delegate.max_entries
+        def __set__(self, value: int):
+            self._delegate.max_entries = value
 
     property threads:
         """:code:`bwa aln -t`"""

--- a/tests/test_libbwaln.py
+++ b/tests/test_libbwaln.py
@@ -32,7 +32,8 @@ def test_bwaaln_options() -> None:
         log_scaled_gap_penalty=False,
         find_all_hits=False,
         with_md=False,
-        threads=13,
+        max_entries=13,
+        threads=14,
     )
 
     assert options.max_mismatches == 1
@@ -50,7 +51,8 @@ def test_bwaaln_options() -> None:
     assert not options.log_scaled_gap_penalty
     assert not options.find_all_hits
     assert not options.with_md
-    assert options.threads == 13
+    assert options.max_entries == 13
+    assert options.threads == 14
 
     options.log_scaled_gap_penalty = True
     assert options.log_scaled_gap_penalty


### PR DESCRIPTION
This controls the maximum entries (candidate locations) in the queue for seeding.

<!-- readthedocs-preview pybwa start -->
----
📚 Documentation preview 📚: https://pybwa--106.org.readthedocs.build/en/106/

<!-- readthedocs-preview pybwa end -->